### PR TITLE
chore: add color scheme config to doc config file

### DIFF
--- a/websites/docs/docusaurus.config.js
+++ b/websites/docs/docusaurus.config.js
@@ -71,7 +71,9 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      colorMode: {},
+      colorMode: {
+        respectPrefersColorScheme: true,
+      },
       navbar: {
         title: 'JSXCSS',
         logo: {


### PR DESCRIPTION
# Overview

I add color scheme config to docusaurus.config.js [bf7e854](https://github.com/jsxcss/react/commit/bf7e8541c724cb174c115c4bb0e1c4a50e81c816)

Using user system preferences, instead of the hardcoded ([referece](https://docusaurus.io/docs/api/themes/configuration#respectPrefersColorScheme))

## Screenshot

https://github.com/jsxcss/react/assets/57122180/52cf88fe-1b00-4574-aeac-379e53b1d691


## PR Checklist

- [x] I have written documents and tests, if needed.
